### PR TITLE
Allow more robust quote escaping inside opt values

### DIFF
--- a/bbcode.py
+++ b/bbcode.py
@@ -225,14 +225,23 @@ class Parser (object):
         attr = ''
         value = ''
         attr_done = False
-        for pos, ch in enumerate(data.strip()):
+        stripped = data.strip()
+        ls = len(stripped)
+        pos = 0
+
+        while pos < ls:
+            ch = stripped[pos]
             if in_value:
                 if in_quote:
-                    if ch == in_quote:
+                    if ch == '\\' and ls > pos+1 and stripped[pos+1] in ('\\', '"', "'"):
+                        value += stripped[pos+1]
+                        pos += 1
+                    elif ch == in_quote:
                         in_quote = False
                         in_value = False
                         if attr:
-                            opts[attr.lower()] = value.strip()
+                            value = value.strip().replace('\\"', '"').replace("\\'", "'")
+                            opts[attr.lower()] = value
                         attr = ''
                         value = ''
                     else:
@@ -265,6 +274,8 @@ class Parser (object):
                         attr = ''
                         attr_done = False
                     attr += ch
+            pos += 1
+
         if attr:
             if name is None:
                 name = attr

--- a/tests.py
+++ b/tests.py
@@ -114,6 +114,21 @@ class ParserTests (unittest.TestCase):
         self.assertEqual(tag_name, 'quote')
         self.assertEqual(opts, {'quote': 'Dan "Darsh" Watson'})
 
+        # combine single and double quotes in a value
+        tag_name, opts = self.parser._parse_opts("quote='Lan \"Please Don\\\'t\" Rogers'")
+        self.assertEqual(tag_name, 'quote')
+        self.assertEqual(opts, {'quote': 'Lan "Please Don\'t" Rogers'})
+
+        # Ensure backslash is still representable
+        tag_name, opts = self.parser._parse_opts("quote='\\\\'")
+        self.assertEqual(tag_name, 'quote')
+        self.assertEqual(opts, {'quote': '\\'})
+
+        # Make sure lookahead for unescaping doesn't go OOB
+        tag_name, opts = self.parser._parse_opts("quote='\\")
+        self.assertEqual(tag_name, 'quote')
+        self.assertEqual(opts, {'quote': '\\'})
+
     def test_strip(self):
         result = self.parser.strip('[b]hello \n[i]world[/i][/b] -- []', strip_newlines=True)
         self.assertEqual(result, 'hello world -- []')


### PR DESCRIPTION
Quoted option values that contain both double and single quotes are currently unrepresentable. This PR introduces backslash escaping of both kinds of quote mark, making these values possible.