### PR TITLE
Refuse to format list items which do not occur within a list tag

### DIFF
--- a/bbcode.py
+++ b/bbcode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-__version_info__ = (1, 0, 31)
+__version_info__ = (1, 0, 32)
 __version__ = '.'.join(str(i) for i in __version_info__)
 
 import re

--- a/bbcode.py
+++ b/bbcode.py
@@ -90,7 +90,7 @@ class Parser (object):
     def __init__(self, newline='<br />', install_defaults=True, escape_html=True,
                  replace_links=True, replace_cosmetic=True, tag_opener='[', tag_closer=']', linker=None,
                  linker_takes_context=False, drop_unrecognized=False, default_context=None,
-                 url_template='<a rel="nofollow" href="{href}">{text}</a>'):
+                 url_template=u'<a rel="nofollow" href="{href}">{text}</a>'):
         self.tag_opener = tag_opener
         self.tag_closer = tag_closer
         self.newline = newline

--- a/bbcode.py
+++ b/bbcode.py
@@ -169,9 +169,16 @@ class Parser (object):
             css = ' style="list-style-type:%s;"' % css_opts[list_type] if list_type in css_opts else ''
             return '<%s%s>%s</%s>' % (tag, css, value, tag)
         self.add_formatter('list', _render_list, transform_newlines=False, strip=True, swallow_trailing_newline=True)
+
         # Make sure transform_newlines = False for [*], so [code] tags can be embedded without transformation.
-        self.add_simple_formatter('*', '<li>%(value)s</li>', newline_closes=True, transform_newlines=False,
+        def _render_list_item(name, value, options, parent, context):
+            if not parent or parent.tag_name != 'list':
+                return '[*]%s<br />' % value
+
+            return '<li>%s</li>' % value
+        self.add_formatter('*', _render_list_item, newline_closes=True, transform_newlines=False,
             same_tag_closes=True, strip=True)
+
         self.add_simple_formatter('quote', '<blockquote>%(value)s</blockquote>', strip=True,
             swallow_trailing_newline=True)
         self.add_simple_formatter('code', '<code>%(value)s</code>', render_embedded=False, transform_newlines=False,

--- a/tests.py
+++ b/tests.py
@@ -44,6 +44,7 @@ class ParserTests (unittest.TestCase):
         ('[url=relative/url.html]link[/url]', '<a rel="nofollow" href="relative/url.html">link</a>'),
         ('[url=/absolute/url.html]link[/url]', '<a rel="nofollow" href="/absolute/url.html">link</a>'),
         ('[url=test.html]page[/url]', '<a rel="nofollow" href="test.html">page</a>'),
+        (u'[URL=ñó]page[/URL]', u'<a rel="nofollow" href="ñó">page</a>'),
         # Tests to make sure links don't get cosmetic replacements.
         ('[url=http://test.com/my--page]test[/url]', '<a rel="nofollow" href="http://test.com/my--page">test</a>'),
         ('http://test.com/my...page(c)', '<a rel="nofollow" href="http://test.com/my...page(c)">http://test.com/my...page(c)</a>'),

--- a/tests.py
+++ b/tests.py
@@ -21,6 +21,8 @@ class ParserTests (unittest.TestCase):
         ('[/asdf][/b]', '[/asdf]'),
         ('[list]\n[*]one\n[*]two\n[/list]', '<ul><li>one</li><li>two</li></ul>'),
         ('[list=1]\n[*]one\n[*]two\n[/list]', '<ol style="list-style-type:decimal;"><li>one</li><li>two</li></ol>'),
+        ('[*]hello\n[*]world\n', '[*]hello<br />[*]world<br />'),
+        ('[b][*]hello\n[*]world\n[/b]', '<strong>[*]hello<br />[*]world<br /></strong>'),
         ('[b\n oops [i]i[/i] forgot[/b]', '[b<br /> oops <em>i</em> forgot'),
         ('[b]over[i]lap[/b]ped[/i]', '<strong>over<em>lap</em></strong>ped'),
         ('>> hey -- a dash...', '&gt;&gt; hey &ndash; a dash&#8230;'),


### PR DESCRIPTION
BBCode such as `[b][*]foo[/b]` will currently render as `<strong><li>foo</li></strong>` which is invalid HTML as `li` elements are not permitted as children of `strong` tags, [spec here](https://www.w3.org/TR/html52/grouping-content.html#the-li-element). Depending on the parser, this can cause a phony list element to be inserted before and as parent to the first errant `li` tag, swallowing the remainder of the document (observed in chrome) or simply fail to parse.

This PR changes this behavior so that `*` tags which are not the immediate child of a `list` tag will not be rendered as HTML.