### PR TITLE
Added `max_tag_depth` parser option to limit tag nesting

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -106,6 +106,17 @@ class ParserTests (unittest.TestCase):
             result = self.parser.format(src)
             self.assertEqual(result, expected)
 
+    def test_max_depth(self):
+        limited_parser = bbcode.Parser(max_tag_depth=2)
+        unlimited_parser = bbcode.Parser()
+
+        src = '[quote][quote][quote]foo[/quote][/quote][/quote]'
+        unlimited_expected = '<blockquote><blockquote><blockquote>foo</blockquote></blockquote></blockquote>'
+        limited_expected = '<blockquote><blockquote>[quote]foo[/quote]</blockquote></blockquote>'
+        
+        self.assertEqual(unlimited_parser.format(src), unlimited_expected)
+        self.assertEqual(limited_parser.format(src), limited_expected)
+
     def test_parse_opts(self):
         tag_name, opts = self.parser._parse_opts('url="http://test.com/s.php?a=bcd efg"  popup')
         self.assertEqual(tag_name, 'url')


### PR DESCRIPTION
Added `max_tag_depth` parser option to limit the amount of tag nesting that will be rendered. Current behavior is than an arbitrary number of nested tags will be accepted, however at some point formatting will run over the max tag depth and throw.

Set the default to 0, meaning unlimited tag depth, in the interest of not breaking anything downstream. However at some point it may make sense to set this to a reasonable value so that recursion depth is limited by default.