### PR TITLE
Fixed incorrect check against max tag depth.

### DIFF
--- a/bbcode.py
+++ b/bbcode.py
@@ -522,7 +522,7 @@ class Parser (object):
         return data
 
     def _format_tokens(self, tokens, parent, escape_html=None, replace_links=None, replace_cosmetic=None,
-            transform_newlines=True, depth=0, **context):
+            transform_newlines=True, depth=1, **context):
         # Allow the parser defaults to be overridden when formatting.
         escape_html = self.escape_html if escape_html is None else escape_html
         replace_links = self.replace_links if replace_links is None else replace_links
@@ -543,7 +543,7 @@ class Parser (object):
                     # If the end tag should not be consumed, back up one (after grabbing the subtokens).
                     if not consume:
                         end = end - 1
-                    if tag.render_embedded and (not depth or depth >= self.max_tag_depth):
+                    if tag.render_embedded and not (self.max_tag_depth and depth >= self.max_tag_depth):
                         # This tag renders embedded tags, simply recurse.
                         inner = self._format_tokens(subtokens, tag, depth=depth+1, **context)
                     else:

--- a/tests.py
+++ b/tests.py
@@ -107,15 +107,18 @@ class ParserTests (unittest.TestCase):
             self.assertEqual(result, expected)
 
     def test_max_depth(self):
-        limited_parser = bbcode.Parser(max_tag_depth=2)
+        limit_one_parser = bbcode.Parser(max_tag_depth=1)
+        limit_two_parser = bbcode.Parser(max_tag_depth=2)
         unlimited_parser = bbcode.Parser()
 
         src = '[quote][quote][quote]foo[/quote][/quote][/quote]'
+        limit_one_expected = '<blockquote>[quote][quote]foo[/quote][/quote]</blockquote>'
+        limit_two_expected = '<blockquote><blockquote>[quote]foo[/quote]</blockquote></blockquote>'
         unlimited_expected = '<blockquote><blockquote><blockquote>foo</blockquote></blockquote></blockquote>'
-        limited_expected = '<blockquote><blockquote>[quote]foo[/quote]</blockquote></blockquote>'
         
+        self.assertEqual(limit_one_parser.format(src), limit_one_expected)
+        self.assertEqual(limit_two_parser.format(src), limit_two_expected)
         self.assertEqual(unlimited_parser.format(src), unlimited_expected)
-        self.assertEqual(limited_parser.format(src), limited_expected)
 
     def test_parse_opts(self):
         tag_name, opts = self.parser._parse_opts('url="http://test.com/s.php?a=bcd efg"  popup')


### PR DESCRIPTION
Sorry for two PRs in a night, realized there was an error in the check for tag depth that happened to produce correct output for max_tag_depth=2, which was the testcase.